### PR TITLE
Caching Tweaks

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -44,7 +44,7 @@ gulp.task('copy-files', ['clean'], function() {
     gulp.src([...orderData, ...dontVulcanizeTheseFiles], {base: './'})
         .pipe(gulp.dest(deployDir));
     return gulp.src([...copyTheseFilesToDist])
-        .pipe(replace('INSERT_VERSION', version))
+        .pipe(replace('INSERT_SHA', git.short()))
         .pipe(debug('copied files'))
         .pipe(gulp.dest(deployDir));
 });
@@ -53,8 +53,6 @@ gulp.task('vulcanize', ['clean'], function() {
 
     var jsFilter = filter(['**/*.js'], {restore: true});
     var htmlFilter = filter(['**/*.html'], {restore: true});
-    var gitsha = git.short();
-    var timestamp = '' + new Date();
 
     return gulp.src('./webclient/index.html')
         .pipe(vulcanize({
@@ -88,8 +86,8 @@ gulp.task('vulcanize', ['clean'], function() {
         .pipe(jsFilter.restore)
 
         .pipe(replace('INSERT_VERSION', version))
-        .pipe(replace('INSERT_SHA', gitsha))
-        .pipe(replace('INSERT_BUILD_TIME', timestamp))
+        .pipe(replace('INSERT_SHA', git.short()))
+        .pipe(replace('INSERT_BUILD_TIME', ''+new Date()))
         .pipe(gulp.dest(deployDir));
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -87,7 +87,7 @@ gulp.task('vulcanize', ['clean'], function() {
 
         .pipe(replace('INSERT_VERSION', version))
         .pipe(replace('INSERT_SHA', git.short()))
-        .pipe(replace('INSERT_BUILD_TIME', ''+new Date()))
+        .pipe(replace('INSERT_BUILD_TIME', new Date().toLocaleString()))
         .pipe(gulp.dest(deployDir));
 });
 

--- a/webclient/index.html
+++ b/webclient/index.html
@@ -50,6 +50,11 @@
                 grid-template-columns: repeat(auto-fill, minmax(200px, 500px));
             }
         </style>
+
+        <script>
+            // this is to help with debugging any SW caching issues if they appear
+            console.debug('script version: INSERT_SHA');
+        </script>
     </head>
     <body>
         <div align="right">INSERT_VERSION</div>

--- a/webclient/sw.js
+++ b/webclient/sw.js
@@ -1,7 +1,7 @@
 let CACHE_NAME = 'order-splitter-cache-INSERT_VERSION';
 let urlsToCache = [
-    // 'index.html', 
-    // 'index.js'
+    'index.html', 
+    'index.js'
 ].map(f => './'+f);
 
 self.addEventListener('install', function(event) {

--- a/webclient/sw.js
+++ b/webclient/sw.js
@@ -1,7 +1,7 @@
 let CACHE_NAME = 'order-splitter-cache-INSERT_VERSION';
 let urlsToCache = [
-    'index.html', 
-    'index.js'
+    // 'index.html', 
+    // 'index.js'
 ].map(f => './'+f);
 
 self.addEventListener('install', function(event) {

--- a/webclient/sw.js
+++ b/webclient/sw.js
@@ -1,4 +1,4 @@
-let CACHE_NAME = 'order-splitter-cache-INSERT_VERSION';
+let CACHE_NAME = 'order-splitter-cache-INSERT_SHA';
 let urlsToCache = [
     'index.html', 
     'index.js'


### PR DESCRIPTION
So, it seems that the service worker cache mainly just prevents me from getting updated versions of the app. It's not very helpful (I'm in a weird state right now where `index.html` is up to date but `index.js` is old). And I think we're doing it wrong. From I remember studying, you're not supposed to cache `index`. You cache everything _except_ `index.html`, and you append sha's to those filenames for when you update and want to bypass the cache.

I think we should disable caching and re-enable when we can do it correctly.