### PR TITLE
Temporarily prevent service worker installation

### DIFF
--- a/webclient/sw-install.js
+++ b/webclient/sw-install.js
@@ -1,4 +1,6 @@
 (function() {
+    console.debug('service worker is disabled for now.');
+    return; // no service worker until we iron bugs out of caching
     let queryParams = new Map(location.search.slice(1).split('&').map(t=>t.split('=')));
     if (location.hostname === 'localhost' && queryParams.get('sw') !== 'test') {
         console.log('service worker disabled on localhost');


### PR DESCRIPTION
Until we iron out #14, perhaps it's best to avoid caching altogether.