### PR TITLE
Uninstall current service worker

### DIFF
--- a/webclient/sw-install.js
+++ b/webclient/sw-install.js
@@ -1,5 +1,11 @@
 (function() {
     console.debug('service worker is disabled for now.');
+    navigator.serviceWorker.getRegistrations().then(function(registrations) {
+        for(let registration of registrations) {
+            console.log('uninstalling old service worker');
+            registration.unregister();
+        } 
+    });
     return; // no service worker until we iron bugs out of caching
     let queryParams = new Map(location.search.slice(1).split('&').map(t=>t.split('=')));
     if (location.hostname === 'localhost' && queryParams.get('sw') !== 'test') {


### PR DESCRIPTION
People have started using the deployed version 56f0697, which installs a service worker with incorrect cache behavior. On our next update, people will see a "Cached files out of sync....please hard refresh" error. I think we should uninstall the service worker so it only happens once for everyone.