### PR TITLE
Clarify instructions

### DIFF
--- a/webclient/index.html
+++ b/webclient/index.html
@@ -144,7 +144,7 @@
                 <div class="step">
                     <h1>How it Works</h1>
                     <span class="number"><h3>1</h3></span>
-                    <span class="step-text">Copy order details from OrderUp</span>
+                    <span class="step-text">Copy OrderUp summary page (⌘-A ⌘-C)</span>
                 </div>
                 <div class="step">
                     <span class="number"><h3>2</h3></span>


### PR DESCRIPTION
Our current users are used to copying _only_ the summary table and then entering tip/fees/tax manually. They won't intuitively know that they can now just copy the whole page.