### PR TITLE
Rearrange results table

### DIFF
--- a/elements/order-split-results-table.html
+++ b/elements/order-split-results-table.html
@@ -30,9 +30,9 @@
                     <td style="font-weight:bold;">Everyone</td>
                     <td>
                         <span class="chip">$[[_prettifyNumber(order.total)]] total<paper-tooltip>subtotal + tax + fees + tip</paper-tooltip></span>
-                        =
                     </td>
                     <td>
+                        =
                         <span class="chip">$[[_prettifyNumber(order.subTotal)]] subtotal<paper-tooltip>sum of item costs</paper-tooltip></span>
                     </td>
                     <td>
@@ -53,9 +53,9 @@
                         <td>[[item.name]]</td>
                         <td>
                             <span class="chip">$[[_computePersonTotal(item.name)]]</span>
-                            =
                         </td>
                         <td>
+                            =
                             <span class="chip">$[[item.price]] price</span>
                         </td>
                         <td>

--- a/elements/order-split-results-table.html
+++ b/elements/order-split-results-table.html
@@ -26,28 +26,6 @@
         </style>
         <div id="main">
             <table>
-                <tr>
-                    <td style="font-weight:bold;">Everyone</td>
-                    <td>
-                        <span class="chip">$[[_prettifyNumber(order.total)]] total<paper-tooltip>subtotal + tax + fees + tip</paper-tooltip></span>
-                    </td>
-                    <td>
-                        =
-                        <span class="chip">$[[_prettifyNumber(order.subTotal)]] subtotal<paper-tooltip>sum of item costs</paper-tooltip></span>
-                    </td>
-                    <td>
-                        +
-                        <span class="chip">$[[_prettifyNumber(order.tax)]] tax</span>
-                    </td>
-                    <td>
-                        +
-                        <span class="chip">$[[_prettifyNumber(order.fee)]] fee</span>
-                    </td>
-                    <td>
-                        +
-                        <span class="chip">$[[_prettifyNumber(order.tipDollars)]] tip</span>
-                    </td>
-                </tr>
                 <template is="dom-repeat" items="[[_computeBreakdownItems(order.people)]]">
                     <tr>
                         <td>[[item.name]]</td>
@@ -72,6 +50,28 @@
                         </td>
                     </tr>
                 </template>
+                <tr>
+                    <td style="font-weight:bold;">Everyone</td>
+                    <td>
+                        <span class="chip">$[[_prettifyNumber(order.total)]] total<paper-tooltip>subtotal + tax + fees + tip</paper-tooltip></span>
+                    </td>
+                    <td>
+                        =
+                        <span class="chip">$[[_prettifyNumber(order.subTotal)]] subtotal<paper-tooltip>sum of item costs</paper-tooltip></span>
+                    </td>
+                    <td>
+                        +
+                        <span class="chip">$[[_prettifyNumber(order.tax)]] tax</span>
+                    </td>
+                    <td>
+                        +
+                        <span class="chip">$[[_prettifyNumber(order.fee)]] fee</span>
+                    </td>
+                    <td>
+                        +
+                        <span class="chip">$[[_prettifyNumber(order.tipDollars)]] tip</span>
+                    </td>
+                </tr>
             </table>
             <paper-button on-tap="_onClipboardTap" raised>Copy to Clipboard</paper-button>
             <textarea id="textForClipboard" value="[[_makeTextForClipboard(order.totals)]]" hidden></textarea>

--- a/elements/order-split-results-table.html
+++ b/elements/order-split-results-table.html
@@ -23,6 +23,12 @@
                 margin: 20px;
                 background: white;
             }
+            .totals-row .chip {
+                font-weight: bold;
+            }
+            .totals-row > td:first-child {
+                font-weight: bold;
+            }
         </style>
         <div id="main">
             <table>
@@ -50,8 +56,8 @@
                         </td>
                     </tr>
                 </template>
-                <tr>
-                    <td style="font-weight:bold;">Everyone</td>
+                <tr class="totals-row">
+                    <td>Everyone</td>
                     <td>
                         <span class="chip">$[[_prettifyNumber(order.subTotal)]] subtotal<paper-tooltip>sum of item costs</paper-tooltip></span>
                     </td>

--- a/elements/order-split-results-table.html
+++ b/elements/order-split-results-table.html
@@ -30,10 +30,6 @@
                     <tr>
                         <td>[[item.name]]</td>
                         <td>
-                            <span class="chip">$[[_computePersonTotal(item.name)]]</span>
-                        </td>
-                        <td>
-                            =
                             <span class="chip">$[[item.price]] price</span>
                         </td>
                         <td>
@@ -48,15 +44,15 @@
                             +
                             <span class="chip">$[[_multiply(item.price, order.tipPercent)]] tip <paper-tooltip>[[item.price]] x [[order.tipPercent]]</paper-tooltip></span>
                         </td>
+                        <td>
+                            =
+                            <span class="chip">$[[_computePersonTotal(item.name)]]</span>
+                        </td>
                     </tr>
                 </template>
                 <tr>
                     <td style="font-weight:bold;">Everyone</td>
                     <td>
-                        <span class="chip">$[[_prettifyNumber(order.total)]] total<paper-tooltip>subtotal + tax + fees + tip</paper-tooltip></span>
-                    </td>
-                    <td>
-                        =
                         <span class="chip">$[[_prettifyNumber(order.subTotal)]] subtotal<paper-tooltip>sum of item costs</paper-tooltip></span>
                     </td>
                     <td>
@@ -70,6 +66,10 @@
                     <td>
                         +
                         <span class="chip">$[[_prettifyNumber(order.tipDollars)]] tip</span>
+                    </td>
+                    <td>
+                        =
+                        <span class="chip">$[[_prettifyNumber(order.total)]] total<paper-tooltip>subtotal + tax + fees + tip</paper-tooltip></span>
                     </td>
                 </tr>
             </table>


### PR DESCRIPTION
Changes:

- The totals row has been moved from the top to the bottom
- The totals column has been moved from the left to the right

Is this an improvement?

| Current | Updated |
| --- | --- |
| ![screenshot from 2017-07-12 21-22-29](https://user-images.githubusercontent.com/2660313/28146494-43e4ee6e-6748-11e7-80ab-48d77d84964f.png) | ![screenshot from 2017-07-12 21-21-52](https://user-images.githubusercontent.com/2660313/28146496-4a063db6-6748-11e7-8533-0a35cb6daf41.png) |

<!--
## Opinion Poll

Click to vote.

[![](https://m131jyck4m.execute-api.us-west-2.amazonaws.com/prod/poll/01BMWSH6QDP1438VZDGHY0C1TZ/Seems%20good)](https://m131jyck4m.execute-api.us-west-2.amazonaws.com/prod/poll/01BMWSH6QDP1438VZDGHY0C1TZ/Seems%20good/vote)
[![](https://m131jyck4m.execute-api.us-west-2.amazonaws.com/prod/poll/01BMWSH6QDP1438VZDGHY0C1TZ/Seems%20bad)](https://m131jyck4m.execute-api.us-west-2.amazonaws.com/prod/poll/01BMWSH6QDP1438VZDGHY0C1TZ/Seems%20bad/vote)
-->

Closes #36 
