### PR TITLE
Show cursor in order input

### DIFF
--- a/elements/order-input.js
+++ b/elements/order-input.js
@@ -43,6 +43,7 @@ export class OrderInput extends PolymerElement {
                 overflow-x: auto;
                 overflow-y: auto;
                 height: 500px;
+                padding: 0.5rem;
             }
         </style>
         <div>


### PR DESCRIPTION
In Chrome, the cursor was showing exactly on the border of the focused div so users couldn't see it. You could sort of see it in Safari and Firefox, but all three are now better.